### PR TITLE
Remove mentions of the public Slack channel.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -8,7 +8,7 @@
   * [Install the Interbit SDK](getting-started/install.md)
   * [Create your first Interbit app](getting-started/create.md)
   * [Run your Interbit app](getting-started/run.md)
-  * [Support](getting-started/support.md)
+  * [Troubleshooting](getting-started/troubleshooting.md)
 
 * [Key Concepts](/key-concepts/README.adoc)
   * [Covenants](/key-concepts/covenants.adoc)
@@ -116,6 +116,6 @@
       * [snapshot](reference/interbit-core/cli/snapshot.md)
       * [startChain](reference/interbit-core/cli/startChain.md)
       * [subscribe](reference/interbit-core/cli/subscribe.adoc)
-* [Support](support/README.md)
+* [Report bugs](bugs.md)
 * [Glossary](GLOSSARY.md)
 

--- a/bugs.md
+++ b/bugs.md
@@ -1,0 +1,4 @@
+# Report bugs
+
+If you encounter a bug while using the Interbit SDK, file an issue on
+our repository: https://github.com/interbit/interbit

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -8,7 +8,7 @@ using Interbit. The topics include:
 * [Install the Interbit SDK](install.md)
 * [Create your first Interbit application](create.md)
 * [Run your Interbit application](run.md)
-* [Support information](support.md)
+* [Troubleshooting](troubleshooting.md)
 
 If you are looking for additional information, see the
 [Examples](/examples/README.md),

--- a/getting-started/troubleshooting.md
+++ b/getting-started/troubleshooting.md
@@ -1,8 +1,8 @@
-# Support
+# Troubleshooting
 
-This section describes a few trouble-shooting suggestions that may help you
-should problems occur. If not, contact us for assistance on our [Slack
-Channel](https://interbitdev.slack.com).
+This section describes a few troubleshooting suggestions that may help you
+should problems occur. If not, feel free to file issues on our GitHub
+repo: https://github.com/interbit/interbit
 
 * Double check the version requirements at the top of this page.
 
@@ -24,7 +24,7 @@ Channel](https://interbitdev.slack.com).
       rm -f package-lock.json
       ```
 
-  1.  Repeat the [dependency installation](install.md#dependencies) and [module
-      build](install.md#modules) steps.
+  1.  Repeat the [dependency installation](install.md#dependencies) and
+      [module build](install.md#modules) steps.
 
   1.  [Run your app](run.md) again.

--- a/index.adoc
+++ b/index.adoc
@@ -18,8 +18,5 @@ no guarantee of data preservation, uptime, stability, or security -- the
 environment is provided "as is" with no express or implied warranty.
 
 We will be updating this environment regularly -- adding functionality,
-applications, and addressing issues. Our
-link:http://slack.test-interbit.io/[Slack community] is open for
-reporting issues, feedback, and announcements of updates to the
-platform.
+applications, and addressing issues.
 =========

--- a/index.adoc
+++ b/index.adoc
@@ -7,8 +7,7 @@ reliability of blockchain technology with much less work and
 maintenance.
 
 The Interbit Software Development Kit (SDK) enables developers to get
-building Interbit powered apps in minutes, not hours. Please let us know
-how your journey is going at our Slack community.
+building Interbit powered apps in minutes, not hours.
 
 [CAUTION]
 =========

--- a/support/README.md
+++ b/support/README.md
@@ -1,5 +1,0 @@
-# Support
-
-
-For direct support and to report bugs, sign up to the Slack channel at http://interbitdev.slack.com.
-


### PR DESCRIPTION
Instead, we recommend filing issues on the Interbit repo.
To do so:

* the "support" topic in the Getting Started section has been renamed to
"troubleshooting".

* The top-level "support" topic has been renamed to "report bugs".

Addresses interbit/interbit#560