### PR TITLE
Initial incorporation of React component detail capture and transformation into Asciidoc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # The default target.
-all: book clean
+all: clean book cleanup
 
 # Declare our phony targets.
 .PHONY: api book clean cleanup debug includes spell test

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,15 @@
 all: book clean
 
 # Declare our phony targets.
-.PHONY: book clean cleanup test spell includes debug
+.PHONY: api book clean cleanup debug includes spell test
 
 book: _book
 
 _book:
 	_bin/make.sh
+
+api:
+	_bin/api.sh
 
 clean:
 	rm -rf _book

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # The default target.
-all: clean book cleanup
+all: clean book
 
 # Declare our phony targets.
 .PHONY: api book clean cleanup debug includes spell test
@@ -16,7 +16,7 @@ clean:
 	rm -rf _book
 
 cleanup:
-	node run clean
+	_bin/cleanup.sh
 
 test: _book
 	npm run test
@@ -28,4 +28,4 @@ includes:
 	npm run includes
 
 debug:
-	./node_modules/.bin/gitbook build --log=debug --debug
+	node_modules/.bin/gitbook build --log=debug --debug

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -101,10 +101,10 @@
   * [interbit-covenant-tools](reference/interbit-covenant-tools/README.md)
     * [validate()](reference/interbit-covenant-tools/validate.adoc)
   * [interbit-ui-components](reference/interbit-ui-components/README.md)
-    * Functions
+    * [Functions](reference/interbit-ui-components/functions.adoc)
       * [formatDate()](reference/interbit-ui-components/formatDate.adoc)
       * [formatDateTime()](reference/interbit-ui-components/formatDateTime.adoc)
-    * React Components
+    * [React components](reference/interbit-ui-components/components.adoc)
       * [UIKit](reference/interbit-ui-components/UIKit/README.adoc)
         * [LinkBar](reference/interbit-ui-components/UIKit/LinkBar.adoc)
   * [interbit-ui-tools](reference/interbit-ui-tools/README.adoc)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -101,8 +101,12 @@
   * [interbit-covenant-tools](reference/interbit-covenant-tools/README.md)
     * [validate()](reference/interbit-covenant-tools/validate.adoc)
   * [interbit-ui-components](reference/interbit-ui-components/README.md)
-    * [formatDate()](reference/interbit-ui-components/formatDate.adoc)
-    * [formatDateTime()](reference/interbit-ui-components/formatDateTime.adoc)
+    * Functions
+      * [formatDate()](reference/interbit-ui-components/formatDate.adoc)
+      * [formatDateTime()](reference/interbit-ui-components/formatDateTime.adoc)
+    * React Components
+      * [UIKit](reference/interbit-ui-components/UIKit/README.adoc)
+        * [LinkBar](reference/interbit-ui-components/UIKit/LinkBar.adoc)
   * [interbit-ui-tools](reference/interbit-ui-tools/README.adoc)
     * [actionCreators](reference/interbit-ui-tools/actionCreators.md)
     * [actionTypes](reference/interbit-ui-tools/actionTypes.md)

--- a/_bin/api.sh
+++ b/_bin/api.sh
@@ -21,5 +21,5 @@ packages=(
 for pkg in ${packages[@]}; do
   echo "Processing package ${pkg}..."
   jsdoc -r -X -c _bin/conf.jsdoc ${PKGDIR}/${pkg} > ${JSONDIR}/${pkg}.json
-  node_modules/gitbook-plugin-interbit/scripts/apijson2adoc.js -j ${JSONDIR}/${pkg}.json -d ${ADOCDIR} -p ${pkg}
+  node_modules/gitbook-plugin-interbit/scripts/apijson2adoc.js -c ${PKGDIR}/${pkg}/src/components -j ${JSONDIR}/${pkg}.json -d ${ADOCDIR} -p ${pkg}
 done

--- a/_bin/api.sh
+++ b/_bin/api.sh
@@ -20,6 +20,6 @@ packages=(
 )
 for pkg in ${packages[@]}; do
   echo "Processing package ${pkg}..."
-  jsdoc -r -X -c _bin/conf.jsdoc ${PKGDIR}/${pkg} > ${JSONDIR}/${pkg}.json
+  node_modules/.bin/jsdoc -r -X -c _bin/conf.jsdoc ${PKGDIR}/${pkg} > ${JSONDIR}/${pkg}.json
   node_modules/gitbook-plugin-interbit/scripts/apijson2adoc.js -c ${PKGDIR}/${pkg}/src/components -j ${JSONDIR}/${pkg}.json -d ${ADOCDIR} -p ${pkg}
 done

--- a/_bin/cleanup.sh
+++ b/_bin/cleanup.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Post-build cleanup
-if [ -d "_book" ]; then
+if [[ -d "_book" ]]; then
   echo -e "\033[34mPerforming post-build cleanup...\033[0m"
   cd _book
-  rm Gemfile Gemfile.lock Makefile Rakefile
+  rm -f Gemfile Gemfile.lock Makefile Rakefile
   rm -f npm-debug.log package.json package-lock.json
-  rm index.js local.js app.json README.md .gitignore
+  rm -f index.js local.js app.json README.md .gitignore
   rm -rf vendor _bin _interbit apiadoc
 else
   echo -e "\033[1m\033[31m*** Looks like the doc build failed!\033[0m"

--- a/_bin/make.sh
+++ b/_bin/make.sh
@@ -6,14 +6,14 @@ echo -e "\033[34mBuilding documentation, please wait...\033[0m"
 bundle install || echo -e "\033[31mRuby dependencies failed to install; make sure Bundler is installed!\033[0m"
 
 # Make sure that `gitbook` command is installed
-if ! [ -x "$(command -v gitbook)" ]; then
+if ! [[ -x "node_modules/.bin/gitbook" && -x "node_modules/.bin/jsdoc" ]]; then
   echo -e "\033[34mInstalling GitBook (and other node dependencies)...\033[0m"
   npm i
 fi
 
 # Install GitBook plugins, themes, etc.
 echo -e "\033[34mInstalling GitBook plugins, themes, etc...\033[0m"
-gitbook install
+node_modules/.bin/gitbook install
 
 # Capture source comments for select packages
 echo -e "\033[34mCollecting API details...\033[0m"
@@ -24,7 +24,7 @@ _bin/api.sh
 
 # Build the book's HTML
 echo -e "\033[34mBuilding the documentation...\033[0m"
-gitbook build
+node_modules/.bin/gitbook build
 
 # Post-build cleanup
 _bin/cleanup.sh

--- a/reference/interbit-ui-components/UIKit/LinkBar.adoc
+++ b/reference/interbit-ui-components/UIKit/LinkBar.adoc
@@ -1,0 +1,3 @@
+= LinkBar
+
+{% include "/apiadoc/interbit-ui-components/UIKit/LinkBar.adoc" %}

--- a/reference/interbit-ui-components/UIKit/README.adoc
+++ b/reference/interbit-ui-components/UIKit/README.adoc
@@ -1,0 +1,4 @@
+= UIKit
+
+The UIKit components provide the visual and interaction elements
+typically involved in Interbit applications.

--- a/reference/interbit-ui-components/components.adoc
+++ b/reference/interbit-ui-components/components.adoc
@@ -1,0 +1,4 @@
+= React components
+
+This section describes each of the React components provided by the
+`interbit-ui-components` package.

--- a/reference/interbit-ui-components/functions.adoc
+++ b/reference/interbit-ui-components/functions.adoc
@@ -1,0 +1,4 @@
+= Functions
+
+This section describes functions provided by the `interbit-ui-tools`
+package.


### PR DESCRIPTION
Properties and `react-styleguidist` example files handled, although we'll likely encounter corner cases when more JSDoc source comments are added to the other components.

Unlike `react-styleguidist`, which appears to perform its own PropTypes introspection, JSDoc marks all properties without source comments as `undocumented`. If the processing logic is adjusted to include them anyway, it would mean all manner of actually undocumented detail would start appearing through the API docs. There might be opportunities to make smarter decisions in the future, but it's either-or right now.